### PR TITLE
Ope 149

### DIFF
--- a/app/components/Buy/Payment.tsx
+++ b/app/components/Buy/Payment.tsx
@@ -41,7 +41,7 @@ const Payment = ({ order }: BuyStepProps) => {
 					<div>
 						<span className="flex flex-row mb-2 text-yellow-600">
 							<ClockIcon className="w-8 mr-2" />
-							<HeaderH2 title="Awaiting Seller Deposit" />
+							<HeaderH2 title="Awaiting Escrow Deposit" />
 						</span>
 						<p className="text-base">
 							{selling

--- a/app/components/Listing/ListType.tsx
+++ b/app/components/Listing/ListType.tsx
@@ -57,21 +57,21 @@ const ListType = ({ updateList, list }: ListStepProps) => {
 
 	return (
 		<StepLayout onProceed={onProceed}>
-			<h2 className="text-xl mt-8 mb-8">Choose the order type to sell or buy crypto</h2>
+			<h2 className="text-xl mt-12 mb-2">Choose order type</h2>
 			<fieldset className="mb-4">
-				<Option
-					type="SellList"
-					title="Sell Order"
-					description="Let users buy crypto from you in exchange for fiat."
-					onClick={setType}
-					selected={type === 'SellList'}
-				/>
 				<Option
 					type="BuyList"
 					title="Buy Order"
-					description="Let users sell their crypto to you in exchange for fiat."
+					description="I want to buy crypto in exchange for fiat"
 					onClick={setType}
 					selected={type === 'BuyList'}
+				/>
+				<Option
+					type="SellList"
+					title="Sell Order"
+					description="I want to sell crypto in exchange for fiat"
+					onClick={setType}
+					selected={type === 'SellList'}
 				/>
 			</fieldset>
 		</StepLayout>

--- a/app/components/Notifications/ExplainerNotification.tsx
+++ b/app/components/Notifications/ExplainerNotification.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable @typescript-eslint/indent */
+import React from 'react';
+
+interface ExplainerNotificationProps {
+	title: string;
+	content: string;
+	info?: boolean;
+	disclamer?: boolean;
+}
+
+const ExplainerNotification = ({ title, content, info = false, disclamer = false }: ExplainerNotificationProps) => (
+	<div
+		className={
+			info
+				? 'bg-[#F7FBFC] text-[#3C9AAA] p-4 rounded'
+				: disclamer
+				? 'bg-[#FEFAF5] text-[#E37A00] p-4 rounded'
+				: 'bg-[#F7FBFC] text-[#3C9AAA] p-4 rounded'
+		}
+	>
+		<p className="text-sm font-bold mb-2">{title}</p>
+		<p className="text-sm">{content}</p>
+	</div>
+);
+
+export default ExplainerNotification;


### PR DESCRIPTION
Task:
https://linear.app/openpeer/issue/OPE-149/helpers-transaction-explainers-and-text-improvements

- **Post Ad - P2P: update page title, buy and sell title and, sub-titles text**
- Change checkbox container position (buy UP sell DOWN)**. 
<img width="1325" alt="post-ad" src="https://github.com/Minke-Labs/openpeer/assets/1265950/c8c3f950-573e-4286-b667-f769fb97fcf8"> 



- **Create Explainer Component**  
<img width="1344" alt="ExplainerNotirication-Component" src="https://github.com/Minke-Labs/openpeer/assets/1265950/1e69611a-98f4-4874-8e28-2a87cb00cc56">
