### PR TITLE
update Modal component styles and improve button component margin Y

### DIFF
--- a/app/components/Button/Button.tsx
+++ b/app/components/Button/Button.tsx
@@ -28,7 +28,7 @@ const Button = ({
 			minimal
 				? 'text-xl font-bold w-8'
 				: outlined
-				? 'w-full px-2 py-3 rounded border border-cyan-600 text-base text-cyan-600 my-8'
+				? 'w-full px-2 py-3 rounded border border-cyan-600 text-base text-cyan-600 my-4'
 				: processing
 				? 'flex flex-row items-center justify-center w-full px-5 py-2.5 rounded bg-cyan-600 text-base text-white'
 				: disabled

--- a/app/components/Modal/ModalWindow.tsx
+++ b/app/components/Modal/ModalWindow.tsx
@@ -35,7 +35,7 @@ const ModalWindow = ({ title, content, type, actionButtonTitle, open, onClose, o
 				</Transition.Child>
 
 				<div className="fixed inset-0 z-10 overflow-y-auto">
-					<div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+					<div className="flex min-h-full items-center justify-center p-4 text-center">
 						<Transition.Child
 							as={Fragment}
 							enter="ease-out duration-300"
@@ -45,7 +45,7 @@ const ModalWindow = ({ title, content, type, actionButtonTitle, open, onClose, o
 							leaveFrom="opacity-100 translate-y-0 sm:scale-100"
 							leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
 						>
-							<Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+							<Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white p-4 text-left shadow-xl transition-all w-full max-w-lg sm:p-6">
 								<div>
 									<div>
 										{type === 'confirmation' ? (
@@ -72,7 +72,7 @@ const ModalWindow = ({ title, content, type, actionButtonTitle, open, onClose, o
 										<Dialog.Title as="h3" className="text-lg font-medium leading-6 text-gray-900">
 											{title}
 										</Dialog.Title>
-										<div className="mt-2">
+										<div className="mt-2 mb-4 md:mb-0">
 											<p className="text-sm text-gray-500">{content}</p>
 										</div>
 									</div>


### PR DESCRIPTION
Mobile Fix:
- Update Modal component styles and improve button component margin Y (checked on all flows, buy, sell, fast buy, trade, tables)

![image](https://github.com/Minke-Labs/openpeer/assets/1265950/23c5742f-6e50-4501-a4f6-70d79e3adfca)
